### PR TITLE
Set preview url false

### DIFF
--- a/services/whatsapp.ts
+++ b/services/whatsapp.ts
@@ -75,7 +75,7 @@ export const sendTextMessage = async ({
         messaging_product: "whatsapp",
         to,
         type: "text",
-        text: { preview_url: true, body: text },
+        text: { preview_url: false, body: text },
       },
     });
   } catch (error: unknown) {


### PR DESCRIPTION
It is to prevent broken preview link like this
<img width="596" height="144" alt="Screenshot 2025-09-02 at 15 02 06" src="https://github.com/user-attachments/assets/5786a1a6-73c8-46ff-abb7-19e75e272229" />
