### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/services/session.ts
+++ b/services/session.ts
@@ -4,24 +4,37 @@ import { config } from "../utils/config";
 import InMemoryDatabase from "../utils/session/in-memory";
 import redis from "../utils/session/redis";
 
+// Accept only digits for waId for extra safety, assume WhatsApp phone format (4-20 digits)
 const schema = z.object({
-  waId: z.string(),
+  waId: z.string().regex(/^\d{4,20}$/),
   conversationId: z.string(),
 });
+
+// Helper to build a safe Redis session key with namespacing
+function getSessionKey(waId: string): string {
+  // At this point, waId should have been validated by zod (schema)
+  // Defensive: limit length as well as type (already regex checked above)
+  return `session:${waId}`;
+}
 
 type Session = z.input<typeof schema>;
 
 const inMemory = new InMemoryDatabase<Session>();
 
 export async function setSession(session: Session) {
+  // Validate waId using Zod; this throws if invalid
+  await schema.pick({ waId: true }).parseAsync({ waId: session.waId });
   if (config.SESSION_DATABASE === "in-memory") {
     inMemory.set(session.waId, session);
   } else if (config.SESSION_DATABASE === "redis") {
-    await redis.set(session.waId, JSON.stringify(session));
+    const key = getSessionKey(session.waId);
+    await redis.set(key, JSON.stringify(session));
   }
 }
 
 export async function getSession(waId: Session["waId"]) {
+  // Validate waId before use
+  await schema.pick({ waId: true }).parseAsync({ waId });
   if (config.SESSION_DATABASE === "in-memory") {
     const item = inMemory.get(waId);
     if (item === null) return null;
@@ -30,7 +43,8 @@ export async function getSession(waId: Session["waId"]) {
 
     return result;
   } else if (config.SESSION_DATABASE === "redis") {
-    const item = await redis.get(waId);
+    const key = getSessionKey(waId);
+    const item = await redis.get(key);
     if (item === null) return null;
 
     const result = await schema.parseAsync(JSON.parse(item));


### PR DESCRIPTION
Potential fix for [https://github.com/hyperjumptech/whatsapp-chatbot-connector/security/code-scanning/2](https://github.com/hyperjumptech/whatsapp-chatbot-connector/security/code-scanning/2)

To mitigate this risk, the best practice is to strictly validate and sanitize all user-controlled data before using it as part of a database (Redis) key. This may include ensuring the value is of expected type and format (e.g., a phone number: only digits, max length) and (optionally) prefixing the key to provide clear namespacing and avoid key collisions. Concretely, in `services/session.ts`, before using `session.waId` (tainted input), we should both validate the format and use a key prefix like `session:`. Since the schema is already defined with Zod, we can further enforce the waId validation (e.g., all digits, with a sensible length check), but minimally, we should namespace the keys to prevent key collisions.

Implement this by:
- Adding a function in `services/session.ts` to sanitize/validate and prefix the session key;
- Replace direct usage of `session.waId` and `waId` for Redis keys with this sanitized/prefixed version, only after a validation pass;
- This requires changes in `setSession` and `getSession`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
